### PR TITLE
Support Airflow 3

### DIFF
--- a/airflow_provider_census/example_dags/example_census.py
+++ b/airflow_provider_census/example_dags/example_census.py
@@ -2,13 +2,12 @@ from airflow_provider_census.operators.census import CensusOperator
 from airflow_provider_census.sensors.census import CensusSensor
 
 from airflow import DAG
-from airflow.utils.dates import days_ago
-from datetime import timedelta
+from datetime import datetime, timedelta
 
 default_args = {
     'owner': 'airflow',
     'depends_on_past': False,
-    'start_date': days_ago(1),
+    'start_date': datetime.today() - timedelta(days=1),
     'email': ['airflow@example.com'],
     'email_on_failure': False,
     'email_on_retry': False,

--- a/airflow_provider_census/operators/census.py
+++ b/airflow_provider_census/operators/census.py
@@ -1,5 +1,13 @@
-from airflow.models import BaseOperator
-from airflow.utils.decorators import apply_defaults
+try:
+    from airflow.models import BaseOperator
+except ImportError: # airflow 2.0
+    from airflow.providers.standard.operators.base import BaseOperator
+
+try:
+    from airflow.utils.decorators import apply_defaults
+except ImportError: # airflow 3.0
+    apply_defaults = lambda f: f
+
 from typing import Any
 
 from airflow_provider_census.hooks.census import CensusHook

--- a/airflow_provider_census/operators/census.py
+++ b/airflow_provider_census/operators/census.py
@@ -1,6 +1,6 @@
 try:
     from airflow.models import BaseOperator
-except ImportError: # airflow 2.0
+except ImportError: # airflow 3.0
     from airflow.providers.standard.operators.base import BaseOperator
 
 try:

--- a/airflow_provider_census/sensors/census.py
+++ b/airflow_provider_census/sensors/census.py
@@ -5,7 +5,10 @@ except ImportError:
 
 from airflow.exceptions import AirflowException
 from airflow_provider_census.hooks.census import CensusHook
-from airflow.utils.decorators import apply_defaults
+try:
+    from airflow.utils.decorators import apply_defaults
+except ImportError: # airflow 3.0
+    apply_defaults = lambda f: f
 
 from airflow_provider_census.hooks.census import CensusHook
 


### PR DESCRIPTION
## Description of the change

Add support for Airflow 3.0, which removed the `apply_defaults` decorator. That decorator has been deprecated since Airflow 2.1

## How tested

Running in Airflow 3.0 locally

## Security implications

None