### PR TITLE
bump version 1.4 to support airflow 3

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "airflow-provider-census"
-version = "1.3.0"
+version = "1.4.0"
 description = "A Census provider for Apache Airflow."
 license = "MIT"
 authors = ["Census <dev@getcensus.com>"]


### PR DESCRIPTION
## Description of the change

Recent [PR](https://github.com/sutrolabs/airflow-provider-census/pull/18) added support for airflow 3, bump version to prepare for release 